### PR TITLE
[9.18] Implemented with_labels_details parameter

### DIFF
--- a/lib/Gitlab/Api/Issues.php
+++ b/lib/Gitlab/Api/Issues.php
@@ -6,15 +6,19 @@ class Issues extends AbstractApi
      * @param int $project_id
      * @param array $parameters (
      *
-     *     @var string $state     Return all issues or just those that are opened or closed.
-     *     @var string $labels    Comma-separated list of label names, issues must have all labels to be returned.
-     *                            No+Label lists all issues with no labels.
-     *     @var string $milestone The milestone title.
-     *     @var string scope      Return issues for the given scope: created-by-me, assigned-to-me or all. Defaults to created-by-me
-     *     @var int[]  $iids      Return only the issues having the given iid.
-     *     @var string $order_by  Return requests ordered by created_at or updated_at fields. Default is created_at.
-     *     @var string $sort      Return requests sorted in asc or desc order. Default is desc.
-     *     @var string $search    Search issues against their title and description.
+     *     @var string $state              Return all issues or just those that are opened or closed.
+     *     @var string $labels             Comma-separated list of label names, issues must have all labels to be
+     *                                     returned. No+Label lists all issues with no labels.
+     *     @var bool $with_labels_details  If true, response will return more details for each label in labels field:
+     *                                     :name, :color, :description, :text_color. Default is false.
+     *     @var string $milestone          The milestone title.
+     *     @var string scope               Return issues for the given scope: created-by-me, assigned-to-me or all.
+     *                                     Defaults to created-by-me
+     *     @var int[]  $iids               Return only the issues having the given iid.
+     *     @var string $order_by           Return requests ordered by created_at or updated_at fields. Default is
+     *                                     created_at.
+     *     @var string $sort               Return requests sorted in asc or desc order. Default is desc.
+     *     @var string $search             Search issues against their title and description.
      * )
      *
      * @return mixed
@@ -27,6 +31,11 @@ class Issues extends AbstractApi
             ->setAllowedValues('state', ['opened', 'closed'])
         ;
         $resolver->setDefined('labels');
+
+        $resolver->setDefined('with_labels_details')
+            ->setAllowedValues('with_labels_details', [true, false])
+        ;
+
         $resolver->setDefined('milestone');
         $resolver->setDefined('iids')
             ->setAllowedTypes('iids', 'array')


### PR DESCRIPTION
I've implemented the `with_labels_details` parameter on the issues resource according to the [GitLab.com Issues API docs](https://docs.gitlab.com/ee/api/issues.html). 

It adds a more detailed version of the `labels` attribute like this:

```php
// Retrieve all issue
$this->gitLabManager->issues()->all(1);

/**
 *  "labels" => array:1 [▼
 *      0 => "Bug"
 *      1 => "Approval"
 *  ]
 */

// Retrieve all issues, with more detailed version of the labels attribute
$this->gitLabManager->issues()->all(1, [
    'with_labels_details' => true,
]);

/**
 *  "labels" => array:2 [▼
 *    0 => array:5 [▼
 *      "id" => 3266
 *      "name" => "Bug"
 *      "color" => "#CC0033"
 *      "description" => "It's bug, not a feature"
 *      "text_color" => "#FFFFFF"
 *    ],
 *    1 => array:5 [▼
 *      "id" => 3280
 *      "name" => "Approval"
 *      "color" => "#35824F"
 *      "description" => "Ready for approval"
 *      "text_color" => "#FFFFFF"
 *    ]
 *  ]
 */
```

Happy #hacktoberfest everybody!