### PR TITLE
[9.18] Adding a single group membership endpoint

### DIFF
--- a/lib/Gitlab/Api/Groups.php
+++ b/lib/Gitlab/Api/Groups.php
@@ -120,6 +120,20 @@ class Groups extends AbstractApi
     }
 
     /**
+     * @param int   $group_id
+     * @param int   $user_id
+     *
+     * @return mixed
+     */
+    public function member($group_id, $user_id)
+    {
+        $resolver = $this->createOptionsResolver();
+        $resolver->setDefined('query');
+
+        return $this->get('groups/'.$this->encodePath($group_id).'/members/'.$this->encodePath($user_id));
+    }
+    
+    /**
      * @param int $group_id
      * @param int $user_id
      * @param int $access_level


### PR DESCRIPTION
See https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project

This only implements this function for groups.